### PR TITLE
Added teleport action

### DIFF
--- a/bungeecord/src/main/java/net/fameless/bungee/BungeeAFKHandler.java
+++ b/bungeecord/src/main/java/net/fameless/bungee/BungeeAFKHandler.java
@@ -2,6 +2,7 @@ package net.fameless.bungee;
 
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.AFKState;
+import net.fameless.core.messaging.RequestType;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -30,17 +31,13 @@ public class BungeeAFKHandler extends AFKHandler implements Listener {
         if (!event.getTag().equals("bungee:bungeeafk")) return;
         String data = new String(event.getData());
         String[] parts = data.split(";");
-
+        if (!RequestType.ACTION_CAUGHT.matches(parts[0])) return;
         if (parts.length != 2) return;
 
-        UUID playerUUID = UUID.fromString(parts[0]);
-        String status = parts[1];
-
-        if (status.equals("action_caught")) {
-            BungeePlayer bungeePlayer = BungeePlayer.adapt(playerUUID).orElse(null);
-            if (bungeePlayer == null) return;
-            bungeePlayer.setTimeSinceLastAction(0);
-            bungeePlayer.setAfkState(AFKState.ACTIVE);
-        }
+        UUID playerUUID = UUID.fromString(parts[1]);
+        BungeePlayer bungeePlayer = BungeePlayer.adapt(playerUUID).orElse(null);
+        if (bungeePlayer == null) return;
+        bungeePlayer.setTimeSinceLastAction(0);
+        bungeePlayer.setAfkState(AFKState.ACTIVE);
     }
 }

--- a/bungeecord/src/main/java/net/fameless/bungee/BungeeAFKHandler.java
+++ b/bungeecord/src/main/java/net/fameless/bungee/BungeeAFKHandler.java
@@ -1,8 +1,11 @@
 package net.fameless.bungee;
 
+import net.fameless.core.BungeeAFK;
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.AFKState;
 import net.fameless.core.messaging.RequestType;
+import net.fameless.core.player.GameMode;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -10,6 +13,7 @@ import net.md_5.bungee.event.EventHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 public class BungeeAFKHandler extends AFKHandler implements Listener {
 
@@ -22,8 +26,22 @@ public class BungeeAFKHandler extends AFKHandler implements Listener {
     @EventHandler
     public void onPostLogin(@NotNull PostLoginEvent event) {
         BungeePlayer bungeePlayer = BungeePlayer.adapt(event.getPlayer());
-        bungeePlayer.setTimeSinceLastAction(0);
-        bungeePlayer.setAfkState(AFKState.ACTIVE);
+        awaitConnectionAndHandleJoin(bungeePlayer, 0);
+    }
+
+    private void awaitConnectionAndHandleJoin(BungeePlayer bungeePlayer, int attempt) {
+        final int maxAttempts = 50; // 50 * 100 ms = 5 second timeout
+
+        BungeePlatform.get().getProxy().getScheduler().schedule(BungeePlatform.get(), () -> {
+            Optional<ProxiedPlayer> playerOpt = bungeePlayer.getPlatformPlayer();
+            if (playerOpt.isPresent() && playerOpt.get().getServer() != null) {
+                handleJoin(bungeePlayer);
+            } else if (attempt < maxAttempts) {
+                awaitConnectionAndHandleJoin(bungeePlayer, attempt + 1);
+            } else {
+                LOGGER.error("Timeout while waiting for player {} to have a valid server connection. Previous states cannot be reverted.", bungeePlayer.getUniqueId());
+            }
+        }, 100, TimeUnit.MILLISECONDS);
     }
 
     @EventHandler
@@ -31,13 +49,49 @@ public class BungeeAFKHandler extends AFKHandler implements Listener {
         if (!event.getTag().equals("bungee:bungeeafk")) return;
         String data = new String(event.getData());
         String[] parts = data.split(";");
-        if (!RequestType.ACTION_CAUGHT.matches(parts[0])) return;
-        if (parts.length != 2) return;
-
-        UUID playerUUID = UUID.fromString(parts[1]);
-        BungeePlayer bungeePlayer = BungeePlayer.adapt(playerUUID).orElse(null);
-        if (bungeePlayer == null) return;
-        bungeePlayer.setTimeSinceLastAction(0);
-        bungeePlayer.setAfkState(AFKState.ACTIVE);
+        if (RequestType.ACTION_CAUGHT.matches(parts[0])) {
+            if (parts.length != 2) return;
+            try {
+                UUID playerUUID = UUID.fromString(parts[1]);
+                BungeePlayer bungeePlayer = BungeePlayer.adapt(playerUUID).orElse(null);
+                if (bungeePlayer == null) return;
+                bungeePlayer.setTimeSinceLastAction(0);
+                bungeePlayer.setAfkState(AFKState.ACTIVE);
+                BungeeAFK.getAFKHandler().handleAction(bungeePlayer);
+            } catch (Exception e) {
+                LOGGER.error("Invalid data received: {} stacktrace: {}", data, e.getMessage());
+            }
+            return;
+        }
+        if (RequestType.GAMEMODE_CHANGE.matches(parts[0])) {
+            if (parts.length < 3) return;
+            try {
+                UUID playerUUID = UUID.fromString(parts[1]);
+                GameMode gameMode = GameMode.valueOf(parts[2].toUpperCase(Locale.ROOT));
+                BungeePlayer bungeePlayer = BungeePlayer.adapt(playerUUID).orElse(null);
+                if (bungeePlayer == null) return;
+                bungeePlayer.setGameMode(gameMode);
+            } catch (Exception e) {
+                LOGGER.error("Invalid game mode data received: {} stacktrace: {}", data, e.getMessage());
+            }
+            return;
+        }
+        if (RequestType.LOCATION_CHANGE.matches(parts[0])) {
+            if (parts.length < 8) return;
+            try {
+                UUID uuid = UUID.fromString(parts[1]);
+                String worldName = parts[2];
+                double x = Double.parseDouble(parts[3]);
+                double y = Double.parseDouble(parts[4]);
+                double z = Double.parseDouble(parts[5]);
+                float yaw = Float.parseFloat(parts[6]);
+                float pitch = Float.parseFloat(parts[7]);
+                BungeePlayer bungeePlayer = BungeePlayer.adapt(uuid).orElse(null);
+                if (bungeePlayer == null) return;
+                bungeePlayer.setLocation(new net.fameless.core.location.Location(worldName, x, y, z, pitch, yaw));
+            } catch (Exception e) {
+                LOGGER.error("Invalid location data received: {} stacktrace: {}", data, e.getMessage());
+            }
+        }
     }
 }

--- a/bungeecord/src/main/java/net/fameless/bungee/BungeePlayer.java
+++ b/bungeecord/src/main/java/net/fameless/bungee/BungeePlayer.java
@@ -3,6 +3,8 @@ package net.fameless.bungee;
 import net.fameless.core.command.framework.CallerType;
 import net.fameless.core.event.EventDispatcher;
 import net.fameless.core.event.PlayerKickEvent;
+import net.fameless.core.location.Location;
+import net.fameless.core.messaging.RequestType;
 import net.fameless.core.player.BAFKPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
@@ -135,5 +137,25 @@ public class BungeePlayer extends BAFKPlayer<ProxiedPlayer> {
         }
         Server playerServer = player.getServer();
         return playerServer != null ? playerServer.getInfo().getName() : "N/A";
+    }
+
+    @Override
+    public void teleport(Location location) {
+        ProxiedPlayer player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            LOGGER.info("player is null, cannot teleport.");
+            return;
+        }
+
+        byte[] data = (RequestType.TELEPORT_PLAYER.name().toLowerCase() + ";" +
+                this.getUniqueId() + ";" +
+                location.getWorldName() + ";" +
+                location.getX() + ";" +
+                location.getY() + ";" +
+                location.getZ() + ";" +
+                location.getYaw() + ";" +
+                location.getPitch()
+        ).getBytes();
+        player.getServer().getInfo().sendData("bungee:bungeeafk", data);
     }
 }

--- a/bungeecord/src/main/java/net/fameless/bungee/BungeePlayer.java
+++ b/bungeecord/src/main/java/net/fameless/bungee/BungeePlayer.java
@@ -6,6 +6,7 @@ import net.fameless.core.event.PlayerKickEvent;
 import net.fameless.core.location.Location;
 import net.fameless.core.messaging.RequestType;
 import net.fameless.core.player.BAFKPlayer;
+import net.fameless.core.player.GameMode;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
@@ -140,7 +141,20 @@ public class BungeePlayer extends BAFKPlayer<ProxiedPlayer> {
     }
 
     @Override
-    public void teleport(Location location) {
+    public void updateGameMode(@NotNull GameMode gameMode) {
+        ProxiedPlayer player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            LOGGER.info("player is null, cannot set gamemode.");
+            return;
+        }
+        byte[] data = (RequestType.GAMEMODE_CHANGE.name().toLowerCase() + ";" +
+                this.getUniqueId() + ";" +
+                gameMode.name()).getBytes();
+        player.getServer().getInfo().sendData("bungee:bungeeafk", data);
+    }
+
+    @Override
+    public void teleport(@NotNull Location location) {
         ProxiedPlayer player = getPlatformPlayer().orElse(null);
         if (player == null) {
             LOGGER.info("player is null, cannot teleport.");

--- a/core/src/main/java/net/fameless/core/BungeeAFK.java
+++ b/core/src/main/java/net/fameless/core/BungeeAFK.java
@@ -11,7 +11,6 @@ import net.fameless.core.config.PluginConfig;
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.Action;
 import net.fameless.core.location.Location;
-import net.fameless.core.player.BAFKPlayer;
 import net.fameless.core.util.PluginUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,10 +59,6 @@ public class BungeeAFK {
         Caption.saveToFile();
         PluginConfig.shutdown();
         afkHandler.shutdown();
-
-        for (BAFKPlayer<?> player : BAFKPlayer.PLAYERS) {
-            afkHandler.handleJoin(player);
-        }
     }
 
     private static void checkForMisconfiguration() {

--- a/core/src/main/java/net/fameless/core/BungeeAFK.java
+++ b/core/src/main/java/net/fameless/core/BungeeAFK.java
@@ -83,7 +83,7 @@ public class BungeeAFK {
         return afkHandler;
     }
 
-    public static BungeeAFKPlatform platform() {
+    public static BungeeAFKPlatform getPlatform() {
         return platform;
     }
 }

--- a/core/src/main/java/net/fameless/core/BungeeAFK.java
+++ b/core/src/main/java/net/fameless/core/BungeeAFK.java
@@ -10,6 +10,8 @@ import net.fameless.core.command.framework.Command;
 import net.fameless.core.config.PluginConfig;
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.Action;
+import net.fameless.core.location.Location;
+import net.fameless.core.player.BAFKPlayer;
 import net.fameless.core.util.PluginUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,7 @@ public class BungeeAFK {
         );
 
         PluginConfig.init();
+        LOGGER.info("Configured AFK-Location: {}", Location.getConfiguredAfkZone());
         PluginUpdater.runTask();
 
         platform = injector.getInstance(BungeeAFKPlatform.class);
@@ -57,6 +60,10 @@ public class BungeeAFK {
         Caption.saveToFile();
         PluginConfig.shutdown();
         afkHandler.shutdown();
+
+        for (BAFKPlayer<?> player : BAFKPlayer.PLAYERS) {
+            afkHandler.handleJoin(player);
+        }
     }
 
     private static void checkForMisconfiguration() {

--- a/core/src/main/java/net/fameless/core/command/AFK.java
+++ b/core/src/main/java/net/fameless/core/command/AFK.java
@@ -35,7 +35,11 @@ public class AFK extends Command {
                 player.setAfkState(AFKState.WARNED);
                 player.setTimeSinceLastAction(afkHandler.getAfkDelayMillis());
             }
-            default -> player.setTimeSinceLastAction(0);
+            default -> {
+                player.setTimeSinceLastAction(0);
+                player.setAfkState(AFKState.ACTIVE);
+                afkHandler.handleAction(player);
+            }
         }
     }
 

--- a/core/src/main/java/net/fameless/core/handling/AFKHandler.java
+++ b/core/src/main/java/net/fameless/core/handling/AFKHandler.java
@@ -3,10 +3,11 @@ package net.fameless.core.handling;
 import net.fameless.core.BungeeAFK;
 import net.fameless.core.caption.Caption;
 import net.fameless.core.config.PluginConfig;
+import net.fameless.core.location.Location;
 import net.fameless.core.player.BAFKPlayer;
 import net.fameless.core.util.Format;
 import net.fameless.core.util.PlayerFilters;
-import net.fameless.core.util.PluginMessage;
+import net.fameless.core.util.MessageBroadcaster;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -77,7 +78,7 @@ public abstract class AFKHandler {
 
         if (action == Action.CONNECT) {
             String serverName = PluginConfig.get().getString("afk-server-name", "");
-            if (!BungeeAFK.platform().doesServerExist(serverName)) {
+            if (!BungeeAFK.getPlatform().doesServerExist(serverName)) {
                 LOGGER.warn("AFK server not found. Defaulting to KICK.");
                 this.action = Action.KICK;
             }
@@ -126,7 +127,7 @@ public abstract class AFKHandler {
                     action.getMessageKey(),
                     TagResolver.resolver("action-delay", Tag.inserting(Component.text(Format.formatTime((int) (timeUntilAction / 1000)))))
             ));
-            PluginMessage.broadcastMessageToFiltered(
+            MessageBroadcaster.broadcastMessageToFiltered(
                     Caption.of("notification.afk_broadcast",
                             TagResolver.resolver("player", Tag.inserting(Component.text(player.getName())))),
                     PlayerFilters.matches(player).negate()
@@ -152,7 +153,7 @@ public abstract class AFKHandler {
                     LOGGER.warn("AFK server not found. Defaulting to KICK.");
                     this.action = Action.KICK;
                     player.kick(Caption.of("notification.afk_kick"));
-                    PluginMessage.broadcastMessageToFiltered(
+                    MessageBroadcaster.broadcastMessageToFiltered(
                             Caption.of("notification.afk_kick_broadcast",
                                     TagResolver.resolver("player", Tag.inserting(Component.text(player.getName())))),
                             PlayerFilters.matches(player).negate()
@@ -164,7 +165,7 @@ public abstract class AFKHandler {
                 playerLastServerMap.put(player, currentServerName);
                 player.connect(afkServerName);
                 player.sendMessage(Caption.of("notification.afk_disconnect"));
-                PluginMessage.broadcastMessageToFiltered(
+                MessageBroadcaster.broadcastMessageToFiltered(
                         Caption.of("notification.afk_disconnect_broadcast",
                                 TagResolver.resolver("player", Tag.inserting(Component.text(player.getName())))),
                         PlayerFilters.matches(player).negate()
@@ -173,7 +174,7 @@ public abstract class AFKHandler {
             }
             case KICK -> {
                 player.kick(Caption.of("notification.afk_kick"));
-                PluginMessage.broadcastMessageToFiltered(
+                MessageBroadcaster.broadcastMessageToFiltered(
                         Caption.of("notification.afk_kick_broadcast",
                                 TagResolver.resolver("player", Tag.inserting(Component.text(player.getName())))));
                 LOGGER.info("Kicked {} for being AFK.", player.getName());

--- a/core/src/main/java/net/fameless/core/handling/Action.java
+++ b/core/src/main/java/net/fameless/core/handling/Action.java
@@ -11,6 +11,7 @@ public enum Action {
 
     KICK,
     CONNECT,
+    TELEPORT,
     NOTHING;
 
     private static final List<Action> excludedActions = new ArrayList<>();

--- a/core/src/main/java/net/fameless/core/handling/Action.java
+++ b/core/src/main/java/net/fameless/core/handling/Action.java
@@ -37,7 +37,7 @@ public enum Action {
 
         String serverName = PluginConfig.get().getString("afk-server-name", null);
         if (serverName == null) return false;
-        return BungeeAFK.platform().doesServerExist(serverName);
+        return BungeeAFK.getPlatform().doesServerExist(serverName);
     }
 
     public static @NotNull List<Action> getAvailableActions() {

--- a/core/src/main/java/net/fameless/core/location/Location.java
+++ b/core/src/main/java/net/fameless/core/location/Location.java
@@ -1,13 +1,28 @@
 package net.fameless.core.location;
 
+import com.google.gson.JsonObject;
+import net.fameless.core.config.PluginConfig;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
 public class Location {
+
+    public static @NotNull Location getConfiguredAfkZone() {
+        Map<String, Object> afkZone = PluginConfig.get().getSection("afk-location");
+        String worldName = afkZone.get("world").toString();
+        double x = Double.parseDouble(afkZone.get("x").toString());
+        double y = Double.parseDouble(afkZone.get("y").toString());
+        double z = Double.parseDouble(afkZone.get("z").toString());
+        return new Location(worldName, x, y, z);
+    }
 
     private String worldName;
     private double x;
     private double y;
     private double z;
-    private float pitch;
-    private float yaw;
+    private float pitch = 0.0f;
+    private float yaw = 0.0f;
 
     public Location(String worldName, double x, double y, double z, float pitch, float yaw) {
         this.worldName = worldName;
@@ -16,6 +31,13 @@ public class Location {
         this.z = z;
         this.pitch = pitch;
         this.yaw = yaw;
+    }
+
+    public Location(String worldName, double x, double y, double z) {
+        this.worldName = worldName;
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     public String getWorldName() {
@@ -64,5 +86,21 @@ public class Location {
 
     public void setYaw(float yaw) {
         this.yaw = yaw;
+    }
+
+    public JsonObject getAsJsonObject() {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("worldName", worldName);
+        obj.addProperty("x", x);
+        obj.addProperty("y", y);
+        obj.addProperty("z", z);
+        obj.addProperty("pitch", pitch);
+        obj.addProperty("yaw", yaw);
+        return obj;
+    }
+
+    @Override
+    public String toString() {
+        return getAsJsonObject().toString();
     }
 }

--- a/core/src/main/java/net/fameless/core/location/Location.java
+++ b/core/src/main/java/net/fameless/core/location/Location.java
@@ -1,0 +1,68 @@
+package net.fameless.core.location;
+
+public class Location {
+
+    private String worldName;
+    private double x;
+    private double y;
+    private double z;
+    private float pitch;
+    private float yaw;
+
+    public Location(String worldName, double x, double y, double z, float pitch, float yaw) {
+        this.worldName = worldName;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.pitch = pitch;
+        this.yaw = yaw;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public void setWorldName(String worldName) {
+        this.worldName = worldName;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public double getZ() {
+        return z;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+
+    public float getPitch() {
+        return pitch;
+    }
+
+    public void setPitch(float pitch) {
+        this.pitch = pitch;
+    }
+
+    public float getYaw() {
+        return yaw;
+    }
+
+    public void setYaw(float yaw) {
+        this.yaw = yaw;
+    }
+}

--- a/core/src/main/java/net/fameless/core/messaging/RequestType.java
+++ b/core/src/main/java/net/fameless/core/messaging/RequestType.java
@@ -1,0 +1,11 @@
+package net.fameless.core.messaging;
+
+public enum RequestType {
+
+    ACTION_CAUGHT,
+    TELEPORT_PLAYER;
+
+    public boolean matches(String name) {
+        return this.name().equalsIgnoreCase(name);
+    }
+}

--- a/core/src/main/java/net/fameless/core/messaging/RequestType.java
+++ b/core/src/main/java/net/fameless/core/messaging/RequestType.java
@@ -3,7 +3,12 @@ package net.fameless.core.messaging;
 public enum RequestType {
 
     ACTION_CAUGHT,
-    TELEPORT_PLAYER;
+    TELEPORT_PLAYER,
+    ENABLE_COLLISION,
+    DISABLE_COLLISION,
+    SET_GAMEMODE,
+    GAMEMODE_CHANGE,
+    LOCATION_CHANGE;
 
     public boolean matches(String name) {
         return this.name().equalsIgnoreCase(name);

--- a/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
+++ b/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
@@ -6,8 +6,9 @@ import net.fameless.core.config.PluginConfig;
 import net.fameless.core.event.EventDispatcher;
 import net.fameless.core.event.PlayerAFKStateChangeEvent;
 import net.fameless.core.handling.AFKState;
+import net.fameless.core.location.Location;
 import net.fameless.core.util.PlayerFilters;
-import net.fameless.core.util.PluginMessage;
+import net.fameless.core.util.MessageBroadcaster;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
@@ -85,7 +86,7 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
 
         if ((this.afkState == AFKState.AFK || this.afkState == AFKState.ACTION_TAKEN) && event.getNewState() == AFKState.ACTIVE) {
             sendMessage(Caption.of("notification.afk_return"));
-            PluginMessage.broadcastMessageToFiltered(
+            MessageBroadcaster.broadcastMessageToFiltered(
                     Caption.of("notification.afk_return_broadcast",
                     TagResolver.resolver("player", Tag.inserting(Component.text(getName())))),
                     PlayerFilters.matches(this).negate()
@@ -121,4 +122,6 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
     public abstract boolean hasPermission(String permission);
 
     public abstract String getCurrentServerName();
+
+    public abstract void teleport(Location location);
 }

--- a/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
+++ b/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
@@ -29,9 +29,14 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
     protected String name;
     private final UUID uuid;
     private long timeSinceLastAction = 0;
-    private AFKState afkState;
+    private AFKState afkState = AFKState.ACTIVE;
+    private GameMode gameMode = GameMode.SURVIVAL;
+    private Location location = new Location("world", 0, 0, 0, 0, 0);
 
     public BAFKPlayer(UUID uuid) {
+        if (of(uuid).isPresent()) {
+            throw new IllegalArgumentException("A player with this UUID already exists: " + uuid);
+        }
         this.uuid = uuid;
         PLAYERS.add(this);
     }
@@ -107,6 +112,22 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
         getAudience().playSound(sound);
     }
 
+    public GameMode getGameMode() {
+        return gameMode;
+    }
+
+    public void setGameMode(GameMode gameMode) {
+        this.gameMode = gameMode;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+
     public abstract String getName();
 
     public abstract Audience getAudience();
@@ -122,6 +143,8 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
     public abstract boolean hasPermission(String permission);
 
     public abstract String getCurrentServerName();
+
+    public abstract void updateGameMode(GameMode gameMode);
 
     public abstract void teleport(Location location);
 }

--- a/core/src/main/java/net/fameless/core/player/GameMode.java
+++ b/core/src/main/java/net/fameless/core/player/GameMode.java
@@ -1,0 +1,10 @@
+package net.fameless.core.player;
+
+public enum GameMode {
+
+    SURVIVAL,
+    CREATIVE,
+    ADVENTURE,
+    SPECTATOR
+
+}

--- a/core/src/main/java/net/fameless/core/util/MessageBroadcaster.java
+++ b/core/src/main/java/net/fameless/core/util/MessageBroadcaster.java
@@ -6,7 +6,7 @@ import net.kyori.adventure.text.Component;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-public class PluginMessage {
+public class MessageBroadcaster {
 
     @SafeVarargs
     public static void broadcastMessageToFiltered(Component message, Predicate<BAFKPlayer<?>> ...filters) {

--- a/core/src/main/java/net/fameless/core/util/PluginPaths.java
+++ b/core/src/main/java/net/fameless/core/util/PluginPaths.java
@@ -19,4 +19,8 @@ public class PluginPaths {
         return new File(BASE_FOLDER, "config.yml");
     }
 
+    public static @NotNull File getPersistedStatesFile() {
+        return new File(BASE_FOLDER + File.separator + "storage", "persisted_states.json");
+    }
+
 }

--- a/core/src/main/java/net/fameless/core/util/YamlUtil.java
+++ b/core/src/main/java/net/fameless/core/util/YamlUtil.java
@@ -32,6 +32,14 @@ public class YamlUtil {
                 "# !!! Only available for BungeeCord and Velocity !!!" + "\n" +
                 "afk-server-name: " + PluginConfig.get().getString("afk-server-name", "") + "\n" +
                 "\n" +
+                "# AFK zone configuration\n" +
+                "# If the action is set to \"teleport\", the player will be teleported to this location\n" +
+                "afk-location:\n" +
+                "  world: " + PluginConfig.get().getSection("afk-location").get("world") + "\n" +
+                "  x: " + PluginConfig.get().getSection("afk-location").get("x") + "\n" +
+                "  y: " + PluginConfig.get().getSection("afk-location").get("y") + "\n" +
+                "  z: " + PluginConfig.get().getSection("afk-location").get("z") + "\n" +
+                "\n" +
                 "# Whether to allow bypass of AFK detection for players with the \"afk.bypass\" permission\n" +
                 "allow-bypass: " + PluginConfig.get().getBoolean("allow-bypass", true) + "\n";
     }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -15,12 +15,21 @@ action-delay: 420
 # Action to be performed after action delay is reached. Possible values: "kick", "connect", "nothing".
 # "kick" - player is kicked from the server
 # "connect" - player is connected to the server specified in the "afk-server-name" option
+# "teleport" - player is teleported to the afk-location as configured below
 # "nothing" - nothing happens
 action: "kick"
 
 # Server name to which the player is connected when the action is set to "connect"
 # !!! Only available for BungeeCord and Velocity !!!
 afk-server-name: "afk"
+
+# AFK Location configuration
+# If the action is set to "teleport", the player will be teleported to this location
+afk-location:
+  world: "world"  # World name where the AFK location is located
+  x: 0.0          # X coordinate of the AFK location
+  y: 100.0        # Y coordinate of the AFK location
+  z: 0.0          # Z coordinate of the AFK location
 
 # Whether to allow bypass of AFK detection for players with the "afk.bypass" permission
 allow-bypass: true

--- a/core/src/main/resources/lang_de.json
+++ b/core/src/main/resources/lang_de.json
@@ -11,6 +11,7 @@
   "notification.afk_kick_broadcast": "<prefix><gray><player> wurde gekickt, weil er zu lange AFK war.",
   "notification.action.kick": "<prefix><gray>Du bist jetzt AFK und wirst in <action-delay> gekickt.",
   "notification.action.connect": "<prefix><gray>Du bist jetzt AFK und wirst in <action-delay> auf den AFK-Server connected.",
+  "notification.action.teleport": "<prefix><gray>Du bist jetzt AFK und wirst in <action-delay> zum AFK-Standort teleportiert.",
   "notification.action.nothing": "<prefix><gray>Du bist jetzt AFK.",
   "notification.action_unavailable": "<prefix><red>Die Aktion ist nicht verfügbar.",
   "permission.no_permission": "<prefix><red>Die fehlt dazu die Berechtigung: <permission>.",

--- a/core/src/main/resources/lang_en.json
+++ b/core/src/main/resources/lang_en.json
@@ -11,6 +11,7 @@
   "notification.afk_kick_broadcast": "<prefix><gray><player> has been kicked for being AFK for too long.",
   "notification.action.kick": "<prefix><gray>You are now AFK and will be kicked in <action-delay>.",
   "notification.action.connect": "<prefix><gray>You are now AFK and will be connected to the AFK server in <action-delay>.",
+  "notification.action.teleport": "<prefix><gray>You are now AFK and will be teleported to the AFK location in <action-delay>.",
   "notification.action.nothing": "<prefix><gray>You are now AFK.",
   "notification.action_unavailable": "<prefix><red>This action is unavailable.",
   "permission.no_permission": "<prefix><red>Insufficient permission: <permission>.",

--- a/core/src/main/resources/persisted_player_states.json
+++ b/core/src/main/resources/persisted_player_states.json
@@ -1,0 +1,11 @@
+{
+  "location": {
+
+  },
+  "game_mode": {
+
+  },
+  "server": {
+
+  }
+}

--- a/spigot/src/main/java/net/fameless/spigot/SpigotAFKHandler.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotAFKHandler.java
@@ -21,6 +21,7 @@ public class SpigotAFKHandler extends AFKHandler implements Listener {
     private void actionCaught(@NotNull SpigotPlayer spigotPlayer) {
         spigotPlayer.setTimeSinceLastAction(0);
         spigotPlayer.setAfkState(AFKState.ACTIVE);
+        handleAction(spigotPlayer);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/spigot/src/main/java/net/fameless/spigot/SpigotLocationAdapter.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotLocationAdapter.java
@@ -6,6 +6,8 @@ import org.bukkit.World;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class SpigotLocationAdapter {
 
     @Contract("_ -> new")
@@ -21,6 +23,18 @@ public class SpigotLocationAdapter {
             location.getZ(),
             location.getYaw(),
             location.getPitch()
+        );
+    }
+
+    @Contract("_ -> new")
+    public static net.fameless.core.location.@NotNull Location adapt(@NotNull Location location) {
+        return new net.fameless.core.location.Location(
+            Objects.requireNonNull(location.getWorld()).getName(),
+            location.getX(),
+            location.getY(),
+            location.getZ(),
+            location.getPitch(),
+            location.getYaw()
         );
     }
 

--- a/spigot/src/main/java/net/fameless/spigot/SpigotLocationAdapter.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotLocationAdapter.java
@@ -1,0 +1,27 @@
+package net.fameless.spigot;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public class SpigotLocationAdapter {
+
+    @Contract("_ -> new")
+    public static @NotNull Location adapt(@NotNull net.fameless.core.location.Location location) {
+        World world = Bukkit.getWorld(location.getWorldName());
+        if (world == null) {
+            throw new IllegalArgumentException("World '" + location.getWorldName() + "' not found for location conversion");
+        }
+        return new Location(
+            world,
+            location.getX(),
+            location.getY(),
+            location.getZ(),
+            location.getYaw(),
+            location.getPitch()
+        );
+    }
+
+}

--- a/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
@@ -121,4 +121,9 @@ public class SpigotPlayer extends BAFKPlayer<Player> {
     public String getCurrentServerName() {
         return ""; // Not needed for SpigotPlatform
     }
+
+    @Override
+    public void teleport(net.fameless.core.location.Location location) {
+        getPlatformPlayer().ifPresent(player -> player.teleport(SpigotLocationAdapter.adapt(location)));
+    }
 }

--- a/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
@@ -136,12 +136,22 @@ public class SpigotPlayer extends BAFKPlayer<Player> {
 
     @Override
     public void updateGameMode(GameMode gameMode) {
-        getPlatformPlayer().ifPresent(player -> player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.name())));
+        Bukkit.getScheduler().runTask(SpigotPlatform.get(), () -> getPlatformPlayer().ifPresent(player -> player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.name()))));
     }
 
     @Override
     public void teleport(net.fameless.core.location.Location location) {
-        getPlatformPlayer().ifPresent(player -> player.teleport(SpigotLocationAdapter.adapt(location)));
+        Bukkit.getScheduler().runTask(SpigotPlatform.get(), () -> getPlatformPlayer().ifPresent(player -> player.teleport(SpigotLocationAdapter.adapt(location))));
+
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        Player player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            return GameMode.SURVIVAL;
+        }
+        return GameMode.valueOf(player.getGameMode().name());
     }
 
 }

--- a/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotPlayer.java
@@ -3,13 +3,16 @@ package net.fameless.spigot;
 import net.fameless.core.command.framework.CallerType;
 import net.fameless.core.event.EventDispatcher;
 import net.fameless.core.event.PlayerKickEvent;
+import net.fameless.core.location.Location;
 import net.fameless.core.player.BAFKPlayer;
+import net.fameless.core.player.GameMode;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -123,7 +126,22 @@ public class SpigotPlayer extends BAFKPlayer<Player> {
     }
 
     @Override
+    public @Nullable Location getLocation() {
+        Player player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            return null;
+        }
+        return SpigotLocationAdapter.adapt(player.getLocation());
+    }
+
+    @Override
+    public void updateGameMode(GameMode gameMode) {
+        getPlatformPlayer().ifPresent(player -> player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.name())));
+    }
+
+    @Override
     public void teleport(net.fameless.core.location.Location location) {
         getPlatformPlayer().ifPresent(player -> player.teleport(SpigotLocationAdapter.adapt(location)));
     }
+
 }

--- a/tracking/src/main/java/net/fameless/bungeeAFKTracking/BungeeAFKTracking.java
+++ b/tracking/src/main/java/net/fameless/bungeeAFKTracking/BungeeAFKTracking.java
@@ -1,6 +1,8 @@
 package net.fameless.bungeeAFKTracking;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -9,11 +11,15 @@ import org.bukkit.event.player.*;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.UUID;
+
+
 public class BungeeAFKTracking extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "bungee:bungeeafk");
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, "bungee:bungeeafk", this::handleIncomingMessage);
         Bukkit.getPluginManager().registerEvents(this, this);
     }
 
@@ -40,7 +46,32 @@ public class BungeeAFKTracking extends JavaPlugin implements Listener {
     }
 
     private void sendBungeeMessage(@NotNull Player player) {
-        byte[] data = (player.getUniqueId() + ";" + "action_caught").getBytes();
+        byte[] data = ("action_caught;" + player.getUniqueId()).getBytes();
         player.sendPluginMessage(this, "bungee:bungeeafk", data);
+    }
+
+    private void handleIncomingMessage(String channel, Player player, byte[] message) {
+        String messageString = new String(message);
+        String[] parts = messageString.split(";");
+        if (parts.length < 1) return;
+        if (!parts[0].equalsIgnoreCase("teleport_player")) return;
+        try {
+            Player targetPlayer = Bukkit.getPlayer(UUID.fromString(parts[1]));
+            World world = Bukkit.getWorld(parts[2]);
+            double x = Double.parseDouble(parts[3]);
+            double y = Double.parseDouble(parts[4]);
+            double z = Double.parseDouble(parts[5]);
+            float yaw = Float.parseFloat(parts[6]);
+            float pitch = Float.parseFloat(parts[7]);
+
+            if (targetPlayer == null || world == null) {
+                getLogger().severe("Invalid teleport data received: " + messageString);
+                return;
+            }
+
+            player.teleport(new Location(world, x, y, z, yaw, pitch));
+        } catch (Exception e) {
+            getLogger().severe("Invalid teleport data received: " + e.getMessage());
+        }
     }
 }

--- a/tracking/src/main/java/net/fameless/bungeeAFKTracking/BungeeAFKTracking.java
+++ b/tracking/src/main/java/net/fameless/bungeeAFKTracking/BungeeAFKTracking.java
@@ -1,6 +1,7 @@
 package net.fameless.bungeeAFKTracking;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -11,6 +12,7 @@ import org.bukkit.event.player.*;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -30,8 +32,10 @@ public class BungeeAFKTracking extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onMove(@NotNull PlayerMoveEvent event) {
+        if (event.getTo() == null) return;
         if (!event.getFrom().equals(event.getTo())) {
             sendBungeeMessage(event.getPlayer());
+            sendLocationChangeMessage(event.getPlayer(), event.getTo());
         }
     }
 
@@ -45,6 +49,33 @@ public class BungeeAFKTracking extends JavaPlugin implements Listener {
         sendBungeeMessage(event.getPlayer());
     }
 
+    @EventHandler
+    public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {
+        sendGamemodeChangeMessage(event.getPlayer(), event.getNewGameMode());
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            sendGamemodeChangeMessage(event.getPlayer(), event.getPlayer().getGameMode());
+            sendLocationChangeMessage(event.getPlayer(), event.getPlayer().getLocation());
+        }, 5L); // Delay to ensure player is fully initialized on proxy platform
+    }
+
+    private void sendLocationChangeMessage(@NotNull Player player, @NotNull Location location) {
+        String message = "location_change;" + player.getUniqueId() + ";" + Objects.requireNonNull(location.getWorld()).getName() + ";" +
+                location.getX() + ";" + location.getY() + ";" + location.getZ() + ";" +
+                location.getYaw() + ";" + location.getPitch();
+        byte[] data = message.getBytes();
+        player.sendPluginMessage(this, "bungee:bungeeafk", data);
+    }
+
+    private void sendGamemodeChangeMessage(@NotNull Player player, @NotNull GameMode gameMode) {
+        String message = "gamemode_change;" + player.getUniqueId() + ";" + gameMode.name();
+        byte[] data = message.getBytes();
+        player.sendPluginMessage(this, "bungee:bungeeafk", data);
+    }
+
     private void sendBungeeMessage(@NotNull Player player) {
         byte[] data = ("action_caught;" + player.getUniqueId()).getBytes();
         player.sendPluginMessage(this, "bungee:bungeeafk", data);
@@ -54,24 +85,44 @@ public class BungeeAFKTracking extends JavaPlugin implements Listener {
         String messageString = new String(message);
         String[] parts = messageString.split(";");
         if (parts.length < 1) return;
-        if (!parts[0].equalsIgnoreCase("teleport_player")) return;
-        try {
-            Player targetPlayer = Bukkit.getPlayer(UUID.fromString(parts[1]));
-            World world = Bukkit.getWorld(parts[2]);
-            double x = Double.parseDouble(parts[3]);
-            double y = Double.parseDouble(parts[4]);
-            double z = Double.parseDouble(parts[5]);
-            float yaw = Float.parseFloat(parts[6]);
-            float pitch = Float.parseFloat(parts[7]);
+        switch (parts[0].toLowerCase()) {
+            case "teleport_player" -> {
+                try {
+                    Player targetPlayer = Bukkit.getPlayer(UUID.fromString(parts[1]));
+                    World world = Bukkit.getWorld(parts[2]);
+                    double x = Double.parseDouble(parts[3]);
+                    double y = Double.parseDouble(parts[4]);
+                    double z = Double.parseDouble(parts[5]);
+                    float yaw = Float.parseFloat(parts[6]);
+                    float pitch = Float.parseFloat(parts[7]);
 
-            if (targetPlayer == null || world == null) {
-                getLogger().severe("Invalid teleport data received: " + messageString);
-                return;
+                    if (targetPlayer == null || world == null) {
+                        getLogger().severe("Invalid teleport data received: " + messageString);
+                        return;
+                    }
+
+                    player.teleport(new Location(world, x, y, z, yaw, pitch));
+                } catch (Exception e) {
+                    getLogger().severe("Invalid teleport data received: " + e.getMessage());
+                }
             }
-
-            player.teleport(new Location(world, x, y, z, yaw, pitch));
-        } catch (Exception e) {
-            getLogger().severe("Invalid teleport data received: " + e.getMessage());
+            case "set_gamemode" -> {
+                if (parts.length < 3) {
+                    getLogger().severe("Invalid set_gamemode data received: " + messageString);
+                    return;
+                }
+                Player targetPlayer = Bukkit.getPlayer(UUID.fromString(parts[1]));
+                if (targetPlayer == null) {
+                    getLogger().severe("Invalid player UUID received for gamemode change: " + parts[1]);
+                    return;
+                }
+                try {
+                    String gameModeString = parts[2];
+                    targetPlayer.setGameMode(GameMode.valueOf(gameModeString));
+                } catch (NumberFormatException e) {
+                    getLogger().severe("Invalid gamemode value received: " + parts[2]);
+                }
+            }
         }
     }
 }

--- a/velocity/src/main/java/net/fameless/velocity/VelocityAFKHandler.java
+++ b/velocity/src/main/java/net/fameless/velocity/VelocityAFKHandler.java
@@ -2,11 +2,13 @@ package net.fameless.velocity;
 
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
-import com.velocitypowered.api.event.connection.PostLoginEvent;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import net.fameless.core.BungeeAFK;
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.AFKState;
 import net.fameless.core.messaging.RequestType;
+import net.fameless.core.player.GameMode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -20,10 +22,9 @@ public class VelocityAFKHandler extends AFKHandler {
     }
 
     @Subscribe
-    public void onPostLogin(@NotNull PostLoginEvent event) {
-        VelocityPlayer velocityPlayer = VelocityPlayer.adapt(event.getPlayer());
-        velocityPlayer.setTimeSinceLastAction(0);
-        velocityPlayer.setAfkState(AFKState.ACTIVE);
+    public void onConnect(@NotNull ServerPostConnectEvent event) {
+        if (event.getPreviousServer() != null) return;
+        handleJoin(VelocityPlayer.adapt(event.getPlayer()));
     }
 
     @Subscribe
@@ -31,13 +32,49 @@ public class VelocityAFKHandler extends AFKHandler {
         if (!event.getIdentifier().getId().equals("bungee:bungeeafk")) return;
         String data = new String(event.getData());
         String[] parts = data.split(";");
-        if (parts.length != 2) return;
-        if (!RequestType.ACTION_CAUGHT.matches(parts[0])) return;
-
-        UUID playerUUID = UUID.fromString(parts[1]);
-        VelocityPlayer velocityPlayer = VelocityPlayer.adapt(playerUUID).orElse(null);
-        if (velocityPlayer == null) return;
-        velocityPlayer.setTimeSinceLastAction(0);
-        velocityPlayer.setAfkState(AFKState.ACTIVE);
+        if (RequestType.ACTION_CAUGHT.matches(parts[0])) {
+            if (parts.length < 2) return;
+            try {
+                UUID playerUUID = UUID.fromString(parts[1]);
+                VelocityPlayer velocityPlayer = VelocityPlayer.adapt(playerUUID).orElse(null);
+                if (velocityPlayer == null) return;
+                velocityPlayer.setTimeSinceLastAction(0);
+                velocityPlayer.setAfkState(AFKState.ACTIVE);
+                BungeeAFK.getAFKHandler().handleAction(velocityPlayer);
+            } catch (Exception e) {
+                LOGGER.error("Invalid data received: {} stacktrace: {}", data, e.getMessage());
+            }
+            return;
+        }
+        if (RequestType.GAMEMODE_CHANGE.matches(parts[0])) {
+            if (parts.length < 3) return;
+            try {
+                UUID playerUUID = UUID.fromString(parts[1]);
+                GameMode gameMode = GameMode.valueOf(parts[2].toUpperCase(Locale.ROOT));
+                VelocityPlayer velocityPlayer = VelocityPlayer.adapt(playerUUID).orElse(null);
+                if (velocityPlayer == null) return;
+                velocityPlayer.setGameMode(gameMode);
+            } catch (Exception e) {
+                LOGGER.error("Invalid game mode data received: {} stacktrace: {}", data, e.getMessage());
+            }
+            return;
+        }
+        if (RequestType.LOCATION_CHANGE.matches(parts[0])) {
+            if (parts.length < 8) return;
+            try {
+                UUID uuid = UUID.fromString(parts[1]);
+                String worldName = parts[2];
+                double x = Double.parseDouble(parts[3]);
+                double y = Double.parseDouble(parts[4]);
+                double z = Double.parseDouble(parts[5]);
+                float yaw = Float.parseFloat(parts[6]);
+                float pitch = Float.parseFloat(parts[7]);
+                VelocityPlayer velocityPlayer = VelocityPlayer.adapt(uuid).orElse(null);
+                if (velocityPlayer == null) return;
+                velocityPlayer.setLocation(new net.fameless.core.location.Location(worldName, x, y, z, pitch, yaw));
+            } catch (Exception e) {
+                LOGGER.error("Invalid location data received: {} stacktrace: {}", data, e.getMessage());
+            }
+        }
     }
 }

--- a/velocity/src/main/java/net/fameless/velocity/VelocityAFKHandler.java
+++ b/velocity/src/main/java/net/fameless/velocity/VelocityAFKHandler.java
@@ -6,6 +6,7 @@ import com.velocitypowered.api.event.connection.PostLoginEvent;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import net.fameless.core.handling.AFKHandler;
 import net.fameless.core.handling.AFKState;
+import net.fameless.core.messaging.RequestType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -30,17 +31,13 @@ public class VelocityAFKHandler extends AFKHandler {
         if (!event.getIdentifier().getId().equals("bungee:bungeeafk")) return;
         String data = new String(event.getData());
         String[] parts = data.split(";");
-
         if (parts.length != 2) return;
+        if (!RequestType.ACTION_CAUGHT.matches(parts[0])) return;
 
-        UUID playerUUID = UUID.fromString(parts[0]);
-        String status = parts[1];
-
-        if (status.equals("action_caught")) {
-            VelocityPlayer velocityPlayer = VelocityPlayer.adapt(playerUUID).orElse(null);
-            if (velocityPlayer == null) return;
-            velocityPlayer.setTimeSinceLastAction(0);
-            velocityPlayer.setAfkState(AFKState.ACTIVE);
-        }
+        UUID playerUUID = UUID.fromString(parts[1]);
+        VelocityPlayer velocityPlayer = VelocityPlayer.adapt(playerUUID).orElse(null);
+        if (velocityPlayer == null) return;
+        velocityPlayer.setTimeSinceLastAction(0);
+        velocityPlayer.setAfkState(AFKState.ACTIVE);
     }
 }

--- a/velocity/src/main/java/net/fameless/velocity/VelocityPlayer.java
+++ b/velocity/src/main/java/net/fameless/velocity/VelocityPlayer.java
@@ -1,9 +1,14 @@
 package net.fameless.velocity;
 
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import net.fameless.core.command.framework.CallerType;
 import net.fameless.core.event.EventDispatcher;
 import net.fameless.core.event.PlayerKickEvent;
+import net.fameless.core.location.Location;
+import net.fameless.core.messaging.RequestType;
 import net.fameless.core.player.BAFKPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
@@ -123,5 +128,30 @@ public class VelocityPlayer extends BAFKPlayer<Player> {
         return player.getCurrentServer()
                 .map(serverConnection -> serverConnection.getServerInfo().getName())
                 .orElse("N/A");
+    }
+
+    @Override
+    public void teleport(Location location) {
+        Player player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            LOGGER.info("player is null, cannot teleport.");
+            return;
+        }
+        ServerConnection connection = player.getCurrentServer().orElse(null);
+        if (connection == null) {
+            LOGGER.info("player is not connected to a server, cannot teleport.");
+            return;
+        }
+        ChannelIdentifier identifier = MinecraftChannelIdentifier.create("bungee", "bungeeafk");
+        connection.sendPluginMessage(identifier,
+                (RequestType.TELEPORT_PLAYER.name().toLowerCase() + ";" +
+                        this.getUniqueId() + ";" +
+                        location.getWorldName() + ";" +
+                        location.getX() + ";" +
+                        location.getY() + ";" +
+                        location.getZ() + ";" +
+                        location.getYaw() + ";" +
+                        location.getPitch()
+                ).getBytes());
     }
 }

--- a/velocity/src/main/java/net/fameless/velocity/VelocityPlayer.java
+++ b/velocity/src/main/java/net/fameless/velocity/VelocityPlayer.java
@@ -10,6 +10,7 @@ import net.fameless.core.event.PlayerKickEvent;
 import net.fameless.core.location.Location;
 import net.fameless.core.messaging.RequestType;
 import net.fameless.core.player.BAFKPlayer;
+import net.fameless.core.player.GameMode;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
@@ -31,10 +32,7 @@ public class VelocityPlayer extends BAFKPlayer<Player> {
 
     public static @NotNull VelocityPlayer adapt(Player player) {
         for (VelocityPlayer velocityPlayer : VELOCITY_PLAYERS) {
-            Optional<Player> platformPlayerOptional = velocityPlayer.getPlatformPlayer();
-            if (platformPlayerOptional.isEmpty()) continue;
-
-            if (velocityPlayer.getPlatformPlayer().get().getUniqueId().equals(player.getUniqueId())) {
+            if (velocityPlayer.getUniqueId().equals(player.getUniqueId())) {
                 return velocityPlayer;
             }
         }
@@ -128,6 +126,26 @@ public class VelocityPlayer extends BAFKPlayer<Player> {
         return player.getCurrentServer()
                 .map(serverConnection -> serverConnection.getServerInfo().getName())
                 .orElse("N/A");
+    }
+
+    @Override
+    public void updateGameMode(GameMode gameMode) {
+        Player player = getPlatformPlayer().orElse(null);
+        if (player == null) {
+            LOGGER.info("player is null, cannot set gamemode.");
+            return;
+        }
+        ServerConnection connection = player.getCurrentServer().orElse(null);
+        if (connection == null) {
+            LOGGER.info("player is not connected to a server, cannot set gamemode.");
+            return;
+        }
+        ChannelIdentifier identifier = MinecraftChannelIdentifier.create("bungee", "bungeeafk");
+        connection.sendPluginMessage(identifier,
+                (RequestType.SET_GAMEMODE.name().toLowerCase() + ";" +
+                        this.getUniqueId() + ";" +
+                        gameMode.name()
+                ).getBytes());
     }
 
     @Override


### PR DESCRIPTION
This PR adds a `teleport` action. When a player goes AFK, they will be teleported to the location defined in config.yml as the `afk-location`, and their gamemode will be updated to `spectator`. Even after a server restart, the previous location and gamemode are preserved, so if a player disconnects while AFK in spectator mode, they will return to their previous gamemode and location when they rejoin, provided no files are deleted.


Additionally, the transition when returning from AFK has been improved and is now instant.