### PR TITLE
Added feature to disable AFK-Detection on proxy subservers

### DIFF
--- a/bungeecord/src/main/java/net/fameless/bungee/BungeePlatform.java
+++ b/bungeecord/src/main/java/net/fameless/bungee/BungeePlatform.java
@@ -2,11 +2,14 @@ package net.fameless.bungee;
 
 import net.fameless.core.BungeeAFK;
 import net.fameless.core.BungeeAFKPlatform;
+import net.fameless.core.ServerEnvironment;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.bstats.bungeecord.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public final class BungeePlatform extends Plugin implements BungeeAFKPlatform {
 
@@ -48,5 +51,15 @@ public final class BungeePlatform extends Plugin implements BungeeAFKPlatform {
     @Override
     public boolean doesServerExist(String serverName) {
         return getProxy().getServerInfo(serverName) != null;
+    }
+
+    @Override
+    public List<String> getServers() {
+        return getProxy().getServers().keySet().stream().toList();
+    }
+
+    @Override
+    public ServerEnvironment getServerEnvironment() {
+        return ServerEnvironment.PROXY;
     }
 }

--- a/core/src/main/java/net/fameless/core/BungeeAFK.java
+++ b/core/src/main/java/net/fameless/core/BungeeAFK.java
@@ -81,6 +81,10 @@ public class BungeeAFK {
         }
     }
 
+    public static boolean isProxy() {
+        return platform.getServerEnvironment() == ServerEnvironment.PROXY;
+    }
+
     public static AFKHandler getAFKHandler() {
         return afkHandler;
     }

--- a/core/src/main/java/net/fameless/core/BungeeAFKPlatform.java
+++ b/core/src/main/java/net/fameless/core/BungeeAFKPlatform.java
@@ -1,7 +1,13 @@
 package net.fameless.core;
 
+import java.util.List;
+
 public interface BungeeAFKPlatform {
 
     boolean doesServerExist(String serverName);
+
+    List<String> getServers();
+
+    ServerEnvironment getServerEnvironment();
 
 }

--- a/core/src/main/java/net/fameless/core/ServerEnvironment.java
+++ b/core/src/main/java/net/fameless/core/ServerEnvironment.java
@@ -1,0 +1,8 @@
+package net.fameless.core;
+
+public enum ServerEnvironment {
+
+    PROXY, // Represents a proxy server environment (e.g., BungeeCord, Velocity)
+    SERVER // Represents a server environment (e.g., Spigot, Paper)
+
+}

--- a/core/src/main/java/net/fameless/core/config/YamlConfig.java
+++ b/core/src/main/java/net/fameless/core/config/YamlConfig.java
@@ -2,6 +2,8 @@ package net.fameless.core.config;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public record YamlConfig(Map<String, Object> data) {
@@ -72,6 +74,14 @@ public record YamlConfig(Map<String, Object> data) {
             return (Map<String, Object>) val;
         }
         throw new IllegalArgumentException("Value for key '" + key + "' is not a Map");
+    }
+
+    public @NotNull List<String> getStringList(String key) {
+        Object val = data.get(key);
+        if (val instanceof List) {
+            return (List<String>) val;
+        }
+        return new ArrayList<>();
     }
 
     public boolean contains(String key) {

--- a/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
+++ b/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
@@ -77,7 +77,9 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
     }
 
     public AFKState getAfkState() {
-        if (PluginConfig.get().getBoolean("allow-bypass") && hasPermission("bungeeafk.bypass")) {
+        if ((PluginConfig.get().getBoolean("allow-bypass") && hasPermission("bungeeafk.bypass")) ||
+                PluginConfig.get().getStringList("disabled-servers").contains(getCurrentServerName())
+        ) {
             return AFKState.BYPASS;
         }
         return afkState;
@@ -88,6 +90,8 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
 
         PlayerAFKStateChangeEvent event = new PlayerAFKStateChangeEvent(this, this.afkState, afkState);
         EventDispatcher.post(event);
+
+        if (event.getNewState() == this.afkState) return;
 
         if ((this.afkState == AFKState.AFK || this.afkState == AFKState.ACTION_TAKEN) && event.getNewState() == AFKState.ACTIVE) {
             sendMessage(Caption.of("notification.afk_return"));

--- a/core/src/main/java/net/fameless/core/util/YamlUtil.java
+++ b/core/src/main/java/net/fameless/core/util/YamlUtil.java
@@ -54,6 +54,12 @@ public class YamlUtil {
 
             # Whether to allow bypass of AFK detection for players with the "afk.bypass" permission
             allow-bypass: %b
+
+            # List of servers where AFK detection is disabled
+            # Players on these servers will not be marked as AFK, and no actions will be performed
+            # Example: [lobby, hub]
+            disabled-servers:
+              %s
             """.formatted(
                 Caption.getCurrentLanguage().getIdentifier(),
                 PluginConfig.get().getInt("warning-delay", 60),
@@ -65,7 +71,8 @@ public class YamlUtil {
                 PluginConfig.get().getSection("afk-location").get("x"),
                 PluginConfig.get().getSection("afk-location").get("y"),
                 PluginConfig.get().getSection("afk-location").get("z"),
-                PluginConfig.get().getBoolean("allow-bypass", true)
+                PluginConfig.get().getBoolean("allow-bypass", true),
+                PluginConfig.get().getStringList("disabled-servers")
         );
     }
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -44,3 +44,9 @@ afk-location:
 
 # Whether to allow bypass of AFK detection for players with the "afk.bypass" permission
 allow-bypass: true
+
+# List of servers where AFK detection is disabled
+# Players on these servers will not be marked as AFK, and no actions will be performed
+# Example: [lobby, hub]
+disabled-servers:
+  []

--- a/core/src/main/resources/lang_de.json
+++ b/core/src/main/resources/lang_de.json
@@ -36,6 +36,13 @@
   "command.afk_bypass": "<prefix><gray>Du umgehst AFK-Checks und kannst deinen AFK-Status daher nicht ändern.",
   "command.language_changed": "<prefix><green>Sprache auf <language> gesetzt.",
   "command.afk_location_set": "<prefix><green>AFK-Standort auf deine aktuelle Position gesetzt.",
+  "command.server_already_disabled": "<prefix><red>Auf dem Server '<server>' ist die AFK-Detection bereits ausgesetzt.",
+  "command.server_disabled": "<prefix><green>Die AFK-Detection wurde auf dem Server '<server>' ausgesetzt.",
+  "command.server_already_enabled": "<prefix><red>Auf dem Server '<server>' ist die AFK-Detection bereits aktiviert.",
+  "command.server_enabled": "<prefix><green>Die AFK-Detection wurde auf dem Server '<server>' aktiviert.",
+  "command.server_not_found": "<prefix><red>Der Server '<server>' wurde nicht gefunden.",
+  "command.disabled_server_list": "<prefix><gray>Ausgesetzte Server: <servers>",
+  "command.only_proxy": "<prefix><red>Dieser Command kann nur auf dem Proxy (BungeeCord, Velocity, etc.) ausgeführt werden.",
   "error.no_caller_type": "<prefix><red>Falscher CallerType.",
   "actionbar.afk": "<blue>Du bist AFK"
 }

--- a/core/src/main/resources/lang_en.json
+++ b/core/src/main/resources/lang_en.json
@@ -36,6 +36,13 @@
   "command.afk_bypass": "<prefix><gray>You are currently bypassing AFK checks and cannot toggle AFK status.",
   "command.language_changed": "<prefix><!bold><green>Language has been updated to <language>.",
   "command.afk_location_set": "<prefix><green>AFK location set to your current position.",
+  "command.server_already_disabled": "<prefix><red>The AFK detection is already disabled on the server '<server>'.",
+  "command.server_disabled": "<prefix><green>The AFK detection has been disabled on the server '<server>'.",
+  "command.server_already_enabled": "<prefix><red>The AFK detection is already enabled on the server '<server>'.",
+  "command.server_enabled": "<prefix><green>The AFK detection has been enabled on the server '<server>'.",
+  "command.server_not_found": "<prefix><red>The server '<server>' was not found.",
+  "command.disabled_server_list": "<prefix><gray>Excluded servers: <servers>",
+  "command.only_proxy": "<prefix><red>This command may only be executed on a proxy (BungeeCord, Velocity, etc.).",
   "error.no_caller_type": "<prefix><red>Invalid CallerType.",
   "actionbar.afk": "<blue>You are AFK"
 }

--- a/spigot/src/main/java/net/fameless/spigot/SpigotPlatform.java
+++ b/spigot/src/main/java/net/fameless/spigot/SpigotPlatform.java
@@ -2,11 +2,17 @@ package net.fameless.spigot;
 
 import net.fameless.core.BungeeAFK;
 import net.fameless.core.BungeeAFKPlatform;
+import net.fameless.core.ServerEnvironment;
 import net.fameless.core.handling.Action;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public final class SpigotPlatform extends JavaPlugin implements BungeeAFKPlatform {
 
@@ -45,5 +51,16 @@ public final class SpigotPlatform extends JavaPlugin implements BungeeAFKPlatfor
     @Override
     public boolean doesServerExist(String serverName) {
         return false;
+    }
+
+    @Contract(pure = true)
+    @Override
+    public @NotNull @Unmodifiable List<String> getServers() {
+        return List.of();
+    }
+
+    @Override
+    public ServerEnvironment getServerEnvironment() {
+        return ServerEnvironment.SERVER;
     }
 }

--- a/velocity/src/main/java/net/fameless/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/net/fameless/velocity/VelocityPlatform.java
@@ -8,9 +8,12 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
 import net.fameless.core.BungeeAFK;
 import net.fameless.core.BungeeAFKPlatform;
+import net.fameless.core.ServerEnvironment;
 import org.bstats.velocity.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 @Plugin(
     id = "bungeeafk",
@@ -66,5 +69,17 @@ public class VelocityPlatform implements BungeeAFKPlatform {
     @Override
     public boolean doesServerExist(String serverName) {
         return proxyServer.getServer(serverName).isPresent();
+    }
+
+    @Override
+    public List<String> getServers() {
+        return proxyServer.getAllServers().stream()
+                .map(server -> server.getServerInfo().getName())
+                .toList();
+    }
+
+    @Override
+    public ServerEnvironment getServerEnvironment() {
+        return ServerEnvironment.PROXY;
     }
 }


### PR DESCRIPTION
This PR introduces the feature to disable AFK-Detection on servers using the `/bafk configure <enable-server|disable-server> <server>` command.