### PR TITLE
Implement bypass-regions feature

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(libs.guice)
     implementation(libs.adventureTextMinimessage)
     implementation(libs.adventureTextSerializerLegacy)
-    implementation(libs.snakeYamlEnginge)
+    implementation(libs.snakeYaml)
     api(libs.slf4j)
     api(libs.logback)
 }

--- a/core/src/main/java/net/fameless/core/config/YamlConfig.java
+++ b/core/src/main/java/net/fameless/core/config/YamlConfig.java
@@ -3,6 +3,7 @@ package net.fameless.core.config;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +74,7 @@ public record YamlConfig(Map<String, Object> data) {
         if (val instanceof Map) {
             return (Map<String, Object>) val;
         }
-        throw new IllegalArgumentException("Value for key '" + key + "' is not a Map");
+        return Collections.emptyMap();
     }
 
     public @NotNull List<String> getStringList(String key) {

--- a/core/src/main/java/net/fameless/core/handling/AFKHandler.java
+++ b/core/src/main/java/net/fameless/core/handling/AFKHandler.java
@@ -165,7 +165,7 @@ public abstract class AFKHandler {
             gameModeObject.addProperty(entry.getKey().toString(), entry.getValue().name());
         }
         for (Map.Entry<UUID, Location> entry : playerPreviousLocationMap.entrySet()) {
-            locationObject.add(entry.getKey().toString(), entry.getValue().getAsJsonObject());
+            locationObject.add(entry.getKey().toString(), entry.getValue().toJson());
         }
 
         JsonObject root = new JsonObject();

--- a/core/src/main/java/net/fameless/core/location/Location.java
+++ b/core/src/main/java/net/fameless/core/location/Location.java
@@ -9,12 +9,11 @@ import java.util.Map;
 public class Location {
 
     public static @NotNull Location getConfiguredAfkZone() {
+        if (!PluginConfig.get().contains("afk-location")) {
+            throw new IllegalStateException("AFK location is not configured in the plugin config.");
+        }
         Map<String, Object> afkZone = PluginConfig.get().getSection("afk-location");
-        String worldName = afkZone.get("world").toString();
-        double x = Double.parseDouble(afkZone.get("x").toString());
-        double y = Double.parseDouble(afkZone.get("y").toString());
-        double z = Double.parseDouble(afkZone.get("z").toString());
-        return new Location(worldName, x, y, z);
+        return fromMap(afkZone);
     }
 
     private String worldName;
@@ -88,7 +87,7 @@ public class Location {
         this.yaw = yaw;
     }
 
-    public JsonObject getAsJsonObject() {
+    public JsonObject toJson() {
         JsonObject obj = new JsonObject();
         obj.addProperty("worldName", worldName);
         obj.addProperty("x", x);
@@ -99,7 +98,17 @@ public class Location {
         return obj;
     }
 
-    public Map<String, Object> getAsMap() {
+    public static @NotNull Location fromJson(@NotNull JsonObject json) {
+        String worldName = json.get("worldName").getAsString();
+        double x = json.get("x").getAsDouble();
+        double y = json.get("y").getAsDouble();
+        double z = json.get("z").getAsDouble();
+        float pitch = json.has("pitch") ? json.get("pitch").getAsFloat() : 0.0f;
+        float yaw = json.has("yaw") ? json.get("yaw").getAsFloat() : 0.0f;
+        return new Location(worldName, x, y, z, pitch, yaw);
+    }
+
+    public Map<String, Object> toMap() {
         return Map.of(
                 "world", worldName,
                 "x", x,
@@ -110,8 +119,23 @@ public class Location {
         );
     }
 
+    public static @NotNull Location fromMap(@NotNull Map<String, Object> map) {
+        String worldName = map.get("world").toString();
+        double x = Double.parseDouble(map.get("x").toString());
+        double y = Double.parseDouble(map.get("y").toString());
+        double z = Double.parseDouble(map.get("z").toString());
+        float pitch = map.containsKey("pitch") ? Float.parseFloat(map.get("pitch").toString()) : 0.0f;
+        float yaw = map.containsKey("yaw") ? Float.parseFloat(map.get("yaw").toString()) : 0.0f;
+        return new Location(worldName, x, y, z, pitch, yaw);
+    }
+
+    public String getCoordinates() {
+        return String.format("X: %.2f, Y: %.2f, Z: %.2f",
+                x, y, z);
+    }
+
     @Override
     public String toString() {
-        return getAsJsonObject().toString();
+        return toJson().toString();
     }
 }

--- a/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
+++ b/core/src/main/java/net/fameless/core/player/BAFKPlayer.java
@@ -7,6 +7,7 @@ import net.fameless.core.event.EventDispatcher;
 import net.fameless.core.event.PlayerAFKStateChangeEvent;
 import net.fameless.core.handling.AFKState;
 import net.fameless.core.location.Location;
+import net.fameless.core.region.Region;
 import net.fameless.core.util.PlayerFilters;
 import net.fameless.core.util.MessageBroadcaster;
 import net.kyori.adventure.audience.Audience;
@@ -78,7 +79,8 @@ public abstract class BAFKPlayer<PlatformPlayer> implements CommandCaller {
 
     public AFKState getAfkState() {
         if ((PluginConfig.get().getBoolean("allow-bypass") && hasPermission("bungeeafk.bypass")) ||
-                PluginConfig.get().getStringList("disabled-servers").contains(getCurrentServerName())
+                PluginConfig.get().getStringList("disabled-servers").contains(getCurrentServerName()) ||
+                Region.isLocationInAnyBypassRegion(location)
         ) {
             return AFKState.BYPASS;
         }

--- a/core/src/main/java/net/fameless/core/region/MockRegion.java
+++ b/core/src/main/java/net/fameless/core/region/MockRegion.java
@@ -1,0 +1,37 @@
+package net.fameless.core.region;
+
+import net.fameless.core.location.Location;
+import org.jetbrains.annotations.NotNull;
+
+// Test region to check whether AFK-Location is within the region.
+public class MockRegion {
+
+    private final String worldName;
+    private final Location corner1;
+    private final Location corner2;
+
+    public MockRegion(@NotNull Location corner1, @NotNull Location corner2) {
+        if (!corner1.getWorldName().equalsIgnoreCase(corner2.getWorldName())) {
+            throw new IllegalArgumentException("Both corners must be in the same world.");
+        }
+
+        this.worldName = corner1.getWorldName();
+        this.corner1 = corner1;
+        this.corner2 = corner2;
+    }
+
+    public boolean isLocationInRegion(@NotNull Location location) {
+        if (!location.getWorldName().equalsIgnoreCase(worldName)) return false;
+
+        double minX = Math.min(corner1.getX(), corner2.getX());
+        double maxX = Math.max(corner1.getX(), corner2.getX());
+        double minY = Math.min(corner1.getY(), corner2.getY());
+        double maxY = Math.max(corner1.getY(), corner2.getY());
+        double minZ = Math.min(corner1.getZ(), corner2.getZ());
+        double maxZ = Math.max(corner1.getZ(), corner2.getZ());
+
+        return location.getX() >= minX && location.getX() <= maxX &&
+                location.getY() >= minY && location.getY() <= maxY &&
+                location.getZ() >= minZ && location.getZ() <= maxZ;
+    }
+}

--- a/core/src/main/java/net/fameless/core/region/Region.java
+++ b/core/src/main/java/net/fameless/core/region/Region.java
@@ -1,0 +1,212 @@
+package net.fameless.core.region;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.fameless.core.location.Location;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.*;
+
+public class Region {
+
+    private static final List<Region> REGIONS = new ArrayList<>();
+
+    private final String regionName;
+    private final String worldName;
+    private final Location corner1;
+    private final Location corner2;
+    private boolean afkDetection;
+
+    public Region(String regionName, @NotNull Location corner1, @NotNull Location corner2, boolean afkDetection) {
+        if (!corner1.getWorldName().equalsIgnoreCase(corner2.getWorldName())) {
+            throw new IllegalArgumentException("Both corners must be in the same world.");
+        }
+
+        for (Region region : REGIONS) {
+            if (region.regionName.equalsIgnoreCase(regionName)) {
+                throw new IllegalArgumentException("Region with name '" + regionName + "' already exists.");
+            }
+        }
+
+        this.regionName = regionName;
+        this.worldName = corner1.getWorldName();
+        this.corner1 = corner1;
+        this.corner2 = corner2;
+        this.afkDetection = afkDetection;
+        REGIONS.add(this);
+    }
+
+    public void toggleAfkDetection() {
+        this.afkDetection = !this.afkDetection;
+    }
+
+    public boolean isAfkDetectionEnabled() {
+        return afkDetection;
+    }
+
+    public String getRegionName() {
+        return regionName;
+    }
+
+    @Contract(pure = true)
+    public static @NotNull @Unmodifiable List<Region> getAllRegions() {
+        return List.copyOf(REGIONS);
+    }
+
+    public static Optional<Region> getRegionByName(@NotNull String regionName) {
+        for (Region region : REGIONS) {
+            if (region.regionName.equalsIgnoreCase(regionName)) {
+                return Optional.of(region);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public Location getCorner1() {
+        return corner1;
+    }
+
+    public Location getCorner2() {
+        return corner2;
+    }
+
+    public boolean isLocationInRegion(@NotNull Location location) {
+        if (!location.getWorldName().equalsIgnoreCase(worldName)) return false;
+
+        double minX = Math.min(corner1.getX(), corner2.getX());
+        double maxX = Math.max(corner1.getX(), corner2.getX());
+        double minY = Math.min(corner1.getY(), corner2.getY());
+        double maxY = Math.max(corner1.getY(), corner2.getY());
+        double minZ = Math.min(corner1.getZ(), corner2.getZ());
+        double maxZ = Math.max(corner1.getZ(), corner2.getZ());
+
+        return location.getX() >= minX && location.getX() <= maxX &&
+                location.getY() >= minY && location.getY() <= maxY &&
+                location.getZ() >= minZ && location.getZ() <= maxZ;
+    }
+
+    public static void removeRegion(@NotNull Region region) {
+        if (!REGIONS.remove(region)) {
+            throw new IllegalArgumentException("Region not found: " + region);
+        }
+    }
+
+    public static void clearRegions() {
+        REGIONS.clear();
+    }
+
+    public static boolean isLocationInAnyRegion(@NotNull Location location) {
+        for (Region region : REGIONS) {
+            if (region.isLocationInRegion(location)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isLocationInAnyBypassRegion(@NotNull Location location) {
+        for (Region region : REGIONS) {
+            if (region.isLocationInRegion(location) && !region.isAfkDetectionEnabled()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Location getMinimumCorner() {
+        return new Location(worldName,
+                Math.min(corner1.getX(), corner2.getX()),
+                Math.min(corner1.getY(), corner2.getY()),
+                Math.min(corner1.getZ(), corner2.getZ())
+        );
+    }
+
+    public Location getMaximumCorner() {
+        return new Location(worldName,
+                Math.max(corner1.getX(), corner2.getX()),
+                Math.max(corner1.getY(), corner2.getY()),
+                Math.max(corner1.getZ(), corner2.getZ())
+        );
+    }
+
+    public double getVolume() {
+        double dx = Math.abs(corner1.getX() - corner2.getX()) + 1;
+        double dy = Math.abs(corner1.getY() - corner2.getY()) + 1;
+        double dz = Math.abs(corner1.getZ() - corner2.getZ()) + 1;
+        return dx * dy * dz;
+    }
+
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        json.addProperty("regionName", regionName);
+        json.addProperty("afkDetection", afkDetection);
+        json.addProperty("worldName", worldName);
+        json.add("corner1", corner1.toJson());
+        json.add("corner2", corner2.toJson());
+        return json;
+    }
+
+    public static @NotNull Region fromJson(@NotNull JsonObject json) {
+        if (!json.has("corner1") || !json.has("corner2") || !json.has("regionName") || !json.has("afkDetection")) {
+            throw new JsonParseException("Failed to deserialize Region: Missing required region params in jsonObject.");
+        }
+        String regionName = json.get("regionName").getAsString();
+        boolean afkDetection = json.get("afkDetection").getAsBoolean();
+        Location corner1 = Location.fromJson(json.getAsJsonObject("corner1"));
+        Location corner2 = Location.fromJson(json.getAsJsonObject("corner2"));
+        return new Region(regionName, corner1, corner2, afkDetection);
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                "regionName", regionName,
+                "afkDetection", afkDetection,
+                "worldName", worldName,
+                "corner1", corner1.toMap(),
+                "corner2", corner2.toMap()
+        );
+    }
+
+    @Contract("_ -> new")
+    public static @NotNull Region fromMap(@NotNull Map<String, Object> map) {
+        if (!map.containsKey("corner1") || !map.containsKey("corner2") || !map.containsKey("regionName") || !map.containsKey("afkDetection")) {
+            throw new IllegalArgumentException("Failed to deserialize Region: Map must contain 'afkDetection', 'corner1', 'corner2' and 'regionName' keys.");
+        }
+        String regionName = (String) map.get("regionName");
+        boolean afkDetection = (boolean) map.get("afkDetection");
+        Location corner1 = Location.fromMap((Map<String, Object>) map.get("corner1"));
+        Location corner2 = Location.fromMap((Map<String, Object>) map.get("corner2"));
+        return new Region(regionName, corner1, corner2, afkDetection);
+    }
+
+    @Override
+    public String toString() {
+        return "Region{" +
+                "regionName='" + regionName + '\'' +
+                "worldName='" + worldName + '\'' +
+                "afkDetection=" + afkDetection +
+                ", corner1=" + corner1 +
+                ", corner2=" + corner2 +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Region region = (Region) o;
+        return regionName.equalsIgnoreCase(region.regionName);
+    }
+
+    @Override
+    public int hashCode() {
+        return regionName.toLowerCase().hashCode();
+    }
+}

--- a/core/src/main/java/net/fameless/core/util/YamlUtil.java
+++ b/core/src/main/java/net/fameless/core/util/YamlUtil.java
@@ -54,7 +54,7 @@ public class YamlUtil {
               y: %s
               z: %s
 
-            # Whether to allow bypass of AFK detection for players with the "afk.bypass" permission
+            # Whether to allow bypass of AFK detection for players with the "afk.bypass" permission (global)
             allow-bypass: %b
 
             # List of servers where AFK detection is disabled
@@ -63,10 +63,10 @@ public class YamlUtil {
             disabled-servers:
               %s
 
-            # Map of regions where AFK detection is disabled
-            # Players in these regions will not be marked as AFK, and no actions will be performed
+            # Map of regions where AFK detection can be toggled on or off independently
+            # Players in regions where AFK detection is false will not be marked as AFK, and no actions will be performed
             # Regions should be added using the /bafk region add <param> command
-            # Manually adding regions here is not recommended but possible, if you know what you're doing
+            # Manually adding regions here is possible, but not recommended, unless you know what you're doing
             %s
             """.formatted(
                 Caption.getCurrentLanguage().getIdentifier(),

--- a/core/src/main/java/net/fameless/core/util/YamlUtil.java
+++ b/core/src/main/java/net/fameless/core/util/YamlUtil.java
@@ -4,6 +4,8 @@ import net.fameless.core.caption.Caption;
 import net.fameless.core.config.PluginConfig;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+
 public class YamlUtil {
 
     public static @NotNull String generateConfig() {
@@ -60,6 +62,12 @@ public class YamlUtil {
             # Example: [lobby, hub]
             disabled-servers:
               %s
+
+            # Map of regions where AFK detection is disabled
+            # Players in these regions will not be marked as AFK, and no actions will be performed
+            # Regions should be added using the /bafk region add <param> command
+            # Manually adding regions here is not recommended but possible, if you know what you're doing
+            %s
             """.formatted(
                 Caption.getCurrentLanguage().getIdentifier(),
                 PluginConfig.get().getInt("warning-delay", 60),
@@ -72,7 +80,8 @@ public class YamlUtil {
                 PluginConfig.get().getSection("afk-location").get("y"),
                 PluginConfig.get().getSection("afk-location").get("z"),
                 PluginConfig.get().getBoolean("allow-bypass", true),
-                PluginConfig.get().getStringList("disabled-servers")
+                PluginConfig.get().getStringList("disabled-servers"),
+                PluginConfig.YAML.dumpAsMap(Map.of("bypass-regions", PluginConfig.get().getSection("bypass-regions")))
         );
     }
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -42,7 +42,7 @@ afk-location:
   y: 100.0        # Y coordinate of the AFK location
   z: 0.0          # Z coordinate of the AFK location
 
-# Whether to allow bypass of AFK detection for players with the "afk.bypass" permission
+# Whether to allow bypass of AFK detection for players with the "afk.bypass" permission (global)
 allow-bypass: true
 
 # List of servers where AFK detection is disabled
@@ -51,8 +51,8 @@ allow-bypass: true
 disabled-servers:
   []
 
-# Map of regions where AFK detection is disabled
-# Players in these regions will not be marked as AFK, and no actions will be performed
+# Map of regions where AFK detection can be toggled on or off independently
+# Players in regions where AFK detection is false will not be marked as AFK, and no actions will be performed
 # Regions should be added using the /bafk region add <param> command
-# Manually adding regions here is not recommended but possible, if you know what you're doing
+# Manually adding regions here is possible, but not recommended, unless you know what you're doing
 bypass-regions:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -50,3 +50,9 @@ allow-bypass: true
 # Example: [lobby, hub]
 disabled-servers:
   []
+
+# Map of regions where AFK detection is disabled
+# Players in these regions will not be marked as AFK, and no actions will be performed
+# Regions should be added using the /bafk region add <param> command
+# Manually adding regions here is not recommended but possible, if you know what you're doing
+bypass-regions:

--- a/core/src/main/resources/lang_de.json
+++ b/core/src/main/resources/lang_de.json
@@ -43,6 +43,18 @@
   "command.server_not_found": "<prefix><red>Der Server '<server>' wurde nicht gefunden.",
   "command.disabled_server_list": "<prefix><gray>Ausgesetzte Server: <servers>",
   "command.only_proxy": "<prefix><red>Dieser Command kann nur auf dem Proxy (BungeeCord, Velocity, etc.) ausgeführt werden.",
+  "command.regions_reloaded": "<prefix><green>Bypass-Regionen erfolgreich neu geladen.",
+  "command.no_regions_found": "<prefix><red>Keine Bypass-Regionen gefunden.",
+  "command.region_list": "<prefix><gray>Bypass-Regionen: <regions>",
+  "command.region_not_found": "<prefix><red>Die Region <region> wurde nicht gefunden.",
+  "command.region_created": "<prefix><green>Bypass-Region <region> erfolgreich erstellt.",
+  "command.region_deleted": "<prefix><green>Bypass-Region <region> erfolgreich gelöscht.",
+  "command.region_already_exists": "<prefix><red>Die Region <region> existiert bereits.",
+  "command.invalid_region_format": "<prefix><red>Ungültiges Regionsformat. Benutze '/bafk region add <region-name> <world-name> <x1> <y1> <z1> <x2> <y2> <z2>'.",
+  "command.config_saved": "<prefix><green>Konfiguration erfolgreich gespeichert.",
+  "command.region_details": "<prefix><gold><br>Details der Region <region>:<gray><br>Welt: <world><br>Ecke 1: <corner1><br>Ecke 2: <corner2><br>AFK-Detection: <afk-detection>",
+  "command.region_detection_toggled": "<prefix><green>AFK-Detection wurde auf '<afk-detection>' für region '<region>' gesetzt.",
+  "command.afk_location_in_region": "<prefix><red>Der AFK-Standort befindet sich in einer Bypass-Region. Das kann zu unerwartetem Verhalten führen. Um trotzdem fortzufahren, führe den command erneut aus.",
   "error.no_caller_type": "<prefix><red>Falscher CallerType.",
   "actionbar.afk": "<blue>Du bist AFK"
 }

--- a/core/src/main/resources/lang_en.json
+++ b/core/src/main/resources/lang_en.json
@@ -43,6 +43,18 @@
   "command.server_not_found": "<prefix><red>The server '<server>' was not found.",
   "command.disabled_server_list": "<prefix><gray>Excluded servers: <servers>",
   "command.only_proxy": "<prefix><red>This command may only be executed on a proxy (BungeeCord, Velocity, etc.).",
+  "command.regions_reloaded": "<prefix><green>Bypass regions reloaded successfully.",
+  "command.no_regions_found": "<prefix><red>No bypass regions found.",
+  "command.region_list": "<prefix><gray>Bypass regions: <regions>",
+  "command.region_not_found": "<prefix><red>No bypass region found with the name <region>.",
+  "command.region_created": "<prefix><green>Bypass region <region> created successfully.",
+  "command.region_deleted": "<prefix><green>Bypass region <region> deleted successfully.",
+  "command.region_already_exists": "<prefix><red>The bypass region <region> already exists.",
+  "command.invalid_region_format": "<prefix><red>Invalid region format. Use '/bafk region add <region-name> <world-name> <x1> <y1> <z1> <x2> <y2> <z2>'.",
+  "command.config_saved": "<prefix><green>Configuration saved successfully.",
+  "command.region_details": "<prefix><gold><br>Details of the region <region>:<gray><br>World: <world><br>Corner 1: <corner1><br>Corner 2: <corner2><br>AFK-Detection: <afk-detection>",
+  "command.region_detection_toggled": "<prefix><green>AFK detection has been <afk-detection> for region '<region>'.",
+  "command.afk_location_in_region": "<prefix><red>The AFK location is within a bypass region. This may lead to unexpected behavior. To proceed anyway, please re-run the command.",
   "error.no_caller_type": "<prefix><red>Invalid CallerType.",
   "actionbar.afk": "<blue>You are AFK"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ adventureBungee = "4.3.4"
 adventueBukkit = "4.3.4"
 slf4j = "2.0.16"
 logback = "1.5.18"
-snakeYamlEngine = "2.10"
+snakeYaml = "2.4"
 
 [libraries]
 bungee = { module = "net.md-5:bungeecord-api", version.ref = "bungee" }
@@ -30,4 +30,4 @@ adventureBungee = { module = "net.kyori:adventure-platform-bungeecord", version.
 adventureBukkit = { module = "net.kyori:adventure-platform-bukkit", version.ref = "adventueBukkit" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-snakeYamlEnginge = { module = "org.snakeyaml:snakeyaml-engine", version.ref = "snakeYamlEngine" }
+snakeYaml = { module = "org.yaml:snakeyaml", version.ref = "snakeYaml" }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(project(":bungeeafk-core"))
     compileOnly(libs.velocity)
     implementation(libs.annotations)
-    implementation(libs.snakeYamlEnginge)
+    implementation(libs.snakeYaml)
     implementation(libs.adventureTextMinimessage)
     implementation(libs.bstatsVelocity)
 }


### PR DESCRIPTION
This PR comes with the following changes;
* Added ability to create regions and to enable/disable AFK detection per region
* Added command to save config during runtime `/bafk configure saveconfig`
* Added command to interact with regions `/bafk regions <reload | list | add | remove | details | toggle-detection> <region>`
* Switched from snakeyaml-engine to snakeyaml