### PR TITLE
Add action bar message configuration for AFK handling

### DIFF
--- a/core/src/main/java/net/fameless/core/handling/AFKHandler.java
+++ b/core/src/main/java/net/fameless/core/handling/AFKHandler.java
@@ -46,6 +46,7 @@ public abstract class AFKHandler {
     private long afkDelay;
     private long actionDelay;
     private BroadcastStrategy broadcastStrategy;
+    private boolean actionBarEnabled;
     private final ScheduledFuture<?> scheduledTask;
 
     public AFKHandler() {
@@ -68,7 +69,9 @@ public abstract class AFKHandler {
                         }
                         handleAction(player);
                         updatePlayerStatus(player);
-                        sendActionBar(player);
+                        if (actionBarEnabled) {
+                            sendActionBar(player);
+                        }
                     });
         } catch (Exception e) {
             LOGGER.error("Error during AFK check task", e);
@@ -132,6 +135,7 @@ public abstract class AFKHandler {
         this.warnDelay = PluginConfig.get().getInt("warning-delay", 300) * 1000L;
         this.afkDelay = PluginConfig.get().getInt("afk-delay", 600) * 1000L;
         this.actionDelay = PluginConfig.get().getInt("action-delay", 630) * 1000L;
+    this.actionBarEnabled = PluginConfig.get().getBoolean("actionbar-enabled", true);
 
         try {
             this.broadcastStrategy = BroadcastStrategy.valueOf(PluginConfig.get().getString("broadcast-strategy", "PER_SERVER"));
@@ -344,6 +348,8 @@ public abstract class AFKHandler {
     }
 
     private void sendActionBar(@NotNull BAFKPlayer<?> player) {
+        if (!actionBarEnabled) return;
+
         if (player.getAfkState().equals(AFKState.AFK)) {
             player.sendActionbar(Caption.of("actionbar.afk"));
         } else if (player.getAfkState().equals(AFKState.ACTION_TAKEN)) {

--- a/core/src/main/java/net/fameless/core/util/YamlUtil.java
+++ b/core/src/main/java/net/fameless/core/util/YamlUtil.java
@@ -29,6 +29,10 @@ public class YamlUtil {
             # This option does not affect auto-clicker or movement pattern detection broadcasts to players with the notify-permission (see below)
             afk-broadcast: %b
 
+            # Whether to send action bar messages while handling AFK states
+            # Affected language keys: 'actionbar.afk', 'actionbar.afk_moved'
+            actionbar-enabled: %b
+
             # Delay after which the warning message is sent to the player (seconds) | Lang entry: "notification.afk_warning"
             # e.g., if set to 60, the player will receive a warning message after 1 minute of inactivity
             warning-delay: %d
@@ -163,6 +167,7 @@ public class YamlUtil {
             """.formatted(
                 Caption.getCurrentLanguage().getIdentifier(),
                 PluginConfig.get().getBoolean("afk-broadcast", true),
+                PluginConfig.get().getBoolean("actionbar-enabled", true),
                 PluginConfig.get().getInt("warning-delay", 60),
                 PluginConfig.get().getInt("afk-delay", 600),
                 PluginConfig.get().getInt("action-delay", 630),

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -16,6 +16,10 @@ lang: en
 # This option does not affect auto-clicker or movement pattern detection broadcasts to players with the notify-permission (see below)
 afk-broadcast: true
 
+# Whether to send action bar messages while handling AFK states
+# Lang entries: 'actionbar.afk', 'actionbar.afk_moved'
+actionbar-enabled: true
+
 # Delay after which the warning message is sent to the player (seconds) | Lang entry: "notification.afk_warning"
 # e.g., if set to 90, the player will receive a warning message after 1 minute and 30 seconds of inactivity
 warning-delay: 90

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -27,6 +27,11 @@ Affected language keys are:
 - `notification.afk_disconnect_broadcast`
 Default is `true`.
 
+#### Action Bar Messages (`actionbar-enabled`)
+Controls whether players receive action bar notifications while AFK handling runs.
+Affected language keys are `actionbar.afk` and `actionbar.afk_moved`.
+Default is `true`.
+
 #### Warning Delay (`warning-delay`)
 This is the delay in seconds after which a warning message is sent to the player after their last activity. The warning message  
 can be customized in the language file under the key `notification.afk_warning`.  


### PR DESCRIPTION
Introduce a configuration option to enable or disable action bar messages during AFK state handling. Update the relevant classes and configuration files to support this feature. Default behavior remains unchanged.